### PR TITLE
Fix references from moshloop to flanksource

### DIFF
--- a/collections/collections.go
+++ b/collections/collections.go
@@ -3,7 +3,7 @@ package collections
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/moshloop/commons/files"
+	"github.com/flanksource/commons/files"
 	"reflect"
 	"strings"
 )

--- a/console/console.go
+++ b/console/console.go
@@ -2,7 +2,7 @@ package console
 
 import (
 	"fmt"
-	"github.com/moshloop/commons/is"
+	"github.com/flanksource/commons/is"
 )
 
 var (

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -11,11 +11,11 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/moshloop/commons/exec"
-	"github.com/moshloop/commons/files"
-	"github.com/moshloop/commons/is"
-	"github.com/moshloop/commons/net"
-	"github.com/moshloop/commons/utils"
+	"github.com/flanksource/commons/exec"
+	"github.com/flanksource/commons/files"
+	"github.com/flanksource/commons/is"
+	"github.com/flanksource/commons/net"
+	"github.com/flanksource/commons/utils"
 )
 
 // Dependency is a struct referring to a version and the templated path
@@ -58,8 +58,8 @@ var dependencies = map[string]Dependency{
 	},
 	"konfigadm": Dependency{
 		Version: "v0.3.6",
-		Linux:   "https://github.com/moshloop/konfigadm/releases/download/{{.version}}/konfigadm",
-		Macosx:  "https://github.com/moshloop/konfigadm/releases/download/{{.version}}/konfigadm_osx",
+		Linux:   "https://github.com/flanksource/konfigadm/releases/download/{{.version}}/konfigadm",
+		Macosx:  "https://github.com/flanksource/konfigadm/releases/download/{{.version}}/konfigadm_osx",
 	},
 	"jb": Dependency{
 		Version: "v0.1.0",

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/moshloop/commons
+module github.com/flanksource/commons
 
 go 1.12
 

--- a/text/template.go
+++ b/text/template.go
@@ -7,8 +7,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
-	"github.com/moshloop/commons/deps"
-	"github.com/moshloop/commons/files"
+	"github.com/flanksource/commons/deps"
+	"github.com/flanksource/commons/files"
 )
 
 var gomplate = deps.Binary("gomplate", "", ".bin")


### PR DESCRIPTION
Changes all the references from `moshloop` git repository to `flanksource`.

Closes #1