### PR TITLE
feat: parse time

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,24 @@
-linters-settings:
-  govet:
-    disable:
-      # printf: non-constant format string in call to fmt.Errorf (govet)
-      # showing up since golangci-lint version 1.60.1
-      - printf
+version: "2"
+linters:
+  settings:
+    govet:
+      disable:
+        - printf
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,8 @@ test:
 .PHONY: lint
 lint:
 	golangci-lint run
+
+.PHONY: tidy
+tidy:
+	go mod tidy	
+

--- a/utils/time.go
+++ b/utils/time.go
@@ -1,0 +1,24 @@
+package utils
+
+import "time"
+
+func ParseTime(t string) *time.Time {
+	formats := []string{
+		time.RFC3339,
+		time.RFC3339Nano,
+		time.ANSIC,
+		time.DateTime,
+		time.DateOnly,
+		"2006-01-02T15:04:05", // ISO8601 without timezone
+		"2006-01-02 15:04:05", // MySQL datetime format
+	}
+
+	for _, format := range formats {
+		parsed, err := time.Parse(format, t)
+		if err == nil {
+			return &parsed
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
`copied from mission-control`