### PR TITLE
fix: don't error out on --help flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/samber/oops v1.17.0
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/sirupsen/logrus v1.9.3
-	github.com/spf13/pflag v1.0.6
+	github.com/spf13/pflag v1.0.10
 	github.com/ulikunitz/xz v0.5.12
 	github.com/vadimi/go-http-ntlm v1.0.3
 	github.com/vadimi/go-http-ntlm/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/logger/default.go
+++ b/logger/default.go
@@ -1,14 +1,16 @@
 package logger
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"regexp"
 	"strings"
 
-	"github.com/flanksource/commons/properties"
 	"github.com/spf13/pflag"
+
+	"github.com/flanksource/commons/properties"
 )
 
 var currentLogger Logger
@@ -33,11 +35,14 @@ func (f *flagSet) bindFlags(flags *pflag.FlagSet) {
 
 func (f *flagSet) Parse() error {
 	logFlagset := pflag.NewFlagSet("logger", pflag.ContinueOnError)
-	logFlagset.ParseErrorsWhitelist = pflag.ParseErrorsWhitelist{UnknownFlags: true}
+	logFlagset.ParseErrorsAllowlist = pflag.ParseErrorsAllowlist{UnknownFlags: true}
 
 	// standalone parsing of flags to ensure we always have the correct values
 	f.bindFlags(logFlagset)
 	if err := logFlagset.Parse(os.Args[1:]); err != nil {
+		if errors.Is(err, pflag.ErrHelp) {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
resolves: https://github.com/flanksource/commons/issues/283


Example:

```
.bin/incident-commander serve --help
Usage of logger:
      --color             Print logs using color (default true)
      --json-logs         Print logs in json format to stderr
  -v, --log-level count   Increase logging level
      --log-to-stderr     Log to stderr instead of stdout
      --report-caller     Report log caller info
error parsing flags: pflag: help requested
Usage:
  incident-commander serve [flags]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded core dependency to latest version for improved stability and performance.

* **Bug Fixes**
  * Improved command-line flag parsing to gracefully handle help requests without errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->