### PR TITLE
feat(http): add retry strategy, context config, and body buffering

### DIFF
--- a/har/har.go
+++ b/har/har.go
@@ -2,7 +2,15 @@
 // capturing outbound request/response pairs for troubleshooting.
 package har
 
+import "github.com/flanksource/commons/properties"
+
 const defaultMaxBodySize = 64 * 1024 // 64 KB
+
+// MaxBodySizeProperty is the -P/properties key that overrides the default
+// per-body capture cap (in bytes). Set e.g. -P http.har.maxBodySize=1048576
+// to capture request/response bodies larger than the 64 KB default, or
+// -P http.har.maxBodySize=0 to capture full bodies with no cap.
+const MaxBodySizeProperty = "http.har.maxBodySize"
 
 // HARConfig controls what the HAR middleware captures and how it redacts.
 type HARConfig struct {
@@ -20,10 +28,13 @@ type HARConfig struct {
 	RedactedHeaders []string
 }
 
-// DefaultConfig returns a HARConfig with sensible defaults.
+// DefaultConfig returns a HARConfig with sensible defaults. The per-body
+// capture cap honours the MaxBodySizeProperty (-P http.har.maxBodySize=…)
+// override; an unset or unparseable value keeps the 64 KB default, and a
+// value <= 0 disables truncation (full bodies captured).
 func DefaultConfig() HARConfig {
 	return HARConfig{
-		MaxBodySize:         defaultMaxBodySize,
+		MaxBodySize:         int64(properties.Int(defaultMaxBodySize, MaxBodySizeProperty)),
 		CaptureContentTypes: []string{"application/json", "application/x-www-form-urlencoded"},
 	}
 }

--- a/har/har_test.go
+++ b/har/har_test.go
@@ -1,0 +1,36 @@
+package har
+
+import (
+	"testing"
+
+	"github.com/flanksource/commons/properties"
+)
+
+func TestDefaultConfig_MaxBodySizeProperty(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		set   bool
+		want  int64
+	}{
+		{name: "unset keeps default", set: false, want: defaultMaxBodySize},
+		{name: "override raises cap", value: "1048576", set: true, want: 1048576},
+		{name: "zero disables truncation", value: "0", set: true, want: 0},
+		{name: "unparseable keeps default", value: "huge", set: true, want: defaultMaxBodySize},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			value := ""
+			if tc.set {
+				value = tc.value
+			}
+			properties.Set(MaxBodySizeProperty, value)
+			defer properties.Set(MaxBodySizeProperty, "")
+
+			if got := DefaultConfig().MaxBodySize; got != tc.want {
+				t.Errorf("MaxBodySize = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/http/client.go
+++ b/http/client.go
@@ -58,6 +58,7 @@ import (
 	"github.com/flanksource/commons/har"
 	"github.com/flanksource/commons/http/middlewares"
 	"github.com/flanksource/commons/logger"
+	"github.com/flanksource/commons/properties"
 	httpntlm "github.com/vadimi/go-http-ntlm"
 	httpntlmv2 "github.com/vadimi/go-http-ntlm/v2"
 )
@@ -75,6 +76,7 @@ var TraceAll = TraceConfig{
 	Body:            true,
 	Response:        true,
 	QueryParam:      true,
+	FormParams:      true,
 	Headers:         true,
 	ResponseHeaders: true,
 	TLS:             true,
@@ -85,6 +87,7 @@ var TraceHeaders = TraceConfig{
 	Body:            false,
 	Response:        false,
 	QueryParam:      true,
+	FormParams:      true,
 	Headers:         true,
 	ResponseHeaders: true,
 	TLS:             false,
@@ -635,10 +638,17 @@ func mergeTraceConfig(dst *TraceConfig, src TraceConfig) {
 	dst.Headers = dst.Headers || src.Headers
 	dst.ResponseHeaders = dst.ResponseHeaders || src.ResponseHeaders
 	dst.QueryParam = dst.QueryParam || src.QueryParam
+	dst.FormParams = dst.FormParams || src.FormParams
 	dst.TLS = dst.TLS || src.TLS
 	dst.Timing = dst.Timing || src.Timing
 	dst.Auth = dst.Auth || src.Auth
+	// A "full" access log (AccessLog && !errorsOnly) from either side wins over
+	// errors-only: if any contributor wants every request logged, the merge does
+	// too. Errors-only survives only when no contributor requested full logging.
+	dstFull := dst.AccessLog && !dst.AccessLogErrorsOnly
+	srcFull := src.AccessLog && !src.AccessLogErrorsOnly
 	dst.AccessLog = dst.AccessLog || src.AccessLog
+	dst.AccessLogErrorsOnly = dst.AccessLog && !dstFull && !srcFull
 	if src.MaxBodyLength > dst.MaxBodyLength {
 		dst.MaxBodyLength = src.MaxBodyLength
 	}
@@ -666,42 +676,87 @@ func appendUnique(dst []string, values ...string) []string {
 	return dst
 }
 
-// traceConfigForLevel maps a logger level to a TraceConfig for the
-// stdout trace middleware. Returns ok=false below Trace1 — no middleware
-// should be installed in that case. Authorization is always redacted so
-// the bearer/key cannot leak.
+type traceLevelOptions struct {
+	baseLevel logger.LogLevel
+}
+
+// TraceLevelOption configures how TraceConfigForLogLevel maps a commons logger
+// level onto the HTTP trace ladder.
+type TraceLevelOption func(*traceLevelOptions)
+
+// WithTraceBaseLevel shifts the whole HTTP trace ladder to start at level.
+// With the default base of Debug, -v logs a single access line; with an Info
+// base, a normal info-level logger logs that access line and -v logs headers.
+func WithTraceBaseLevel(level logger.LogLevel) TraceLevelOption {
+	return func(opts *traceLevelOptions) {
+		opts.baseLevel = level
+	}
+}
+
+// TraceConfigForLogLevel maps a logger level to a TraceConfig for the stdout
+// trace middleware. The ladder is relative to a configurable base level:
 //
-//	level < Trace1   : none
-//	level >= Trace1  : QueryParam + Headers + ResponseHeaders (the "-vvv" line)
-//	level >= Trace2  : the above + Body + Response + TLS, MaxBodyLength=4096
-func traceConfigForLevel(level logger.LogLevel) (TraceConfig, bool) {
-	switch {
-	case level >= logger.Trace2:
-		return TraceConfig{
-			MaxBodyLength:   4096,
-			Body:            true,
-			Response:        true,
-			QueryParam:      true,
-			Headers:         true,
-			ResponseHeaders: true,
-			TLS:             true,
-			RedactedHeaders: []string{"Authorization"},
-		}, true
-	case level >= logger.Trace1:
-		return TraceConfig{
-			QueryParam:      true,
-			Headers:         true,
-			ResponseHeaders: true,
-			RedactedHeaders: []string{"Authorization"},
-		}, true
-	default:
+//	base + 0: access line only
+//	base + 1: query/form params + request/response headers
+//	base + 2: request bodies + concise TLS
+//	base + 3: response bodies
+//
+// The default base is Debug and can be overridden with http.log.base-level,
+// HTTP_LOG_BASE_LEVEL, or WithTraceBaseLevel.
+func TraceConfigForLogLevel(level logger.LogLevel, options ...TraceLevelOption) (TraceConfig, bool) {
+	opts := traceLevelOptions{baseLevel: configuredTraceBaseLevel()}
+	for _, option := range options {
+		if option != nil {
+			option(&opts)
+		}
+	}
+
+	// One level below base (INFO when base is the default Debug) installs the
+	// access-log middleware in error-only mode: logPrettyAccess emits at INFO
+	// for transport errors and responses >= 400 (with body), and stays silent
+	// for successes. This surfaces failing requests at -v=0 without the
+	// per-request access spam that full access logging (base level) produces.
+	if level < opts.baseLevel-1 {
 		return TraceConfig{}, false
 	}
+
+	config := TraceConfig{
+		AccessLog:           true,
+		AccessLogErrorsOnly: level < opts.baseLevel,
+		RedactedHeaders:     []string{"Authorization"},
+	}
+	if level >= opts.baseLevel+1 {
+		config.QueryParam = true
+		config.FormParams = true
+		config.Headers = true
+		config.ResponseHeaders = true
+	}
+	if level >= opts.baseLevel+2 {
+		config.MaxBodyLength = 4096
+		config.Body = true
+		config.TLS = true
+	}
+	if level >= opts.baseLevel+3 {
+		config.MaxBodyLength = 4096
+		config.Response = true
+	}
+	return config, true
+}
+
+func configuredTraceBaseLevel() logger.LogLevel {
+	level := strings.TrimSpace(os.Getenv("HTTP_LOG_BASE_LEVEL"))
+	if level == "" {
+		level = strings.TrimSpace(properties.String("", "http.log.base-level"))
+	}
+	if level == "" {
+		return logger.Debug
+	}
+	return logger.ParseLevel(logger.GetLogger(), level)
 }
 
 // WithLogger stores l as the client's logger AND, as a side effect,
 // installs a stdout trace middleware whose config is derived from
-// l.GetLevel() via traceConfigForLevel. This makes -vvv / -vvvv "just
+// l.GetLevel() via TraceConfigForLogLevel. This makes -v / -vv "just
 // work" by passing the application's standard logger:
 //
 //	NewClient().WithLogger(logger.StandardLogger())
@@ -710,7 +765,7 @@ func traceConfigForLevel(level logger.LogLevel) (TraceConfig, bool) {
 // TraceToStdout's dedupe — calling both is safe and merges configs.
 func (c *Client) WithLogger(l logger.Logger) *Client {
 	c.logger = l
-	if cfg, ok := traceConfigForLevel(l.GetLevel()); ok {
+	if cfg, ok := TraceConfigForLogLevel(l.GetLevel()); ok {
 		c = c.TraceToStdout(cfg)
 	}
 	return c

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -60,7 +60,7 @@ func TestHTTP(t *testing.T) {
 		req := http.NewClient().InsecureSkipVerify(true).R(ctx)
 		response, err := req.Get("https://expired.badssl.com/")
 		if err != nil {
-			t.Errorf("error: %v", err)
+			t.Fatalf("error: %v", err)
 		}
 
 		if !response.IsOK() {
@@ -73,7 +73,7 @@ func TestHTTP(t *testing.T) {
 		for i := 0; i < 5; i++ {
 			response, err := req.Get("https://github.com/")
 			if err != nil {
-				t.Errorf("error: %v", err)
+				t.Fatalf("error: %v", err)
 			}
 
 			if !response.IsOK() {
@@ -105,7 +105,7 @@ func TestHTTP(t *testing.T) {
 			postReq := client.R(ctx).Header("Scope", "request")
 			response, err := postReq.Post("products/add", map[string]string{"title": "test"})
 			if err != nil {
-				t.Errorf("error: %v", err)
+				t.Fatalf("error: %v", err)
 			}
 
 			var bodyResponse = map[string]any{}
@@ -122,7 +122,7 @@ func TestHTTP(t *testing.T) {
 			req := client.R(ctx)
 			response, err := req.Get("products/1")
 			if err != nil {
-				t.Errorf("error: %v", err)
+				t.Fatalf("error: %v", err)
 			}
 
 			if !response.IsOK() {

--- a/http/middlewares/logger.go
+++ b/http/middlewares/logger.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	commonsCtx "github.com/flanksource/commons/context"
 	"github.com/flanksource/commons/logger"
 	"github.com/flanksource/commons/logger/httpretty"
+	"github.com/flanksource/commons/properties"
 )
 
 type jsonFormatter struct{}
@@ -68,24 +70,11 @@ func getLogger(req *http.Request) logger.Logger {
 	return commonsCtx.LoggerFromContext(req.Context())
 }
 
-func isSensitiveHeader(key string) bool {
-	for _, h := range logger.SensitiveHeaders {
-		if strings.EqualFold(h, key) {
-			return true
-		}
-	}
-	return false
-}
-
-func headerMap(h http.Header) map[string]string {
+func headerMap(h http.Header, redactedHeaders ...string) map[string]string {
+	h = logger.SanitizeHeaders(h, redactedHeaders...)
 	m := make(map[string]string, len(h))
 	for k, v := range h {
-		joined := strings.Join(v, ", ")
-		if isSensitiveHeader(k) {
-			m[k] = logger.PrintableSecret(joined)
-		} else {
-			m[k] = joined
-		}
+		m[k] = strings.Join(v, ", ")
 	}
 	return m
 }
@@ -121,6 +110,63 @@ func sanitizeBody(body string) any {
 	return body
 }
 
+func formParams(req *http.Request) (url.Values, bool) {
+	if req == nil || req.Body == nil {
+		return nil, false
+	}
+	mediaType, _, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/x-www-form-urlencoded" {
+		return nil, false
+	}
+	body, restored := readBody(req.Body)
+	req.Body = restored
+	values, err := url.ParseQuery(body)
+	if err != nil || len(values) == 0 {
+		return nil, false
+	}
+	return values, true
+}
+
+func valueMap(values url.Values) map[string]string {
+	m := make(map[string]string, len(values))
+	for key, vals := range values {
+		joined := strings.Join(vals, ",")
+		if logger.IsSensitiveKey(key) {
+			joined = logger.PrintableSecret(joined)
+		}
+		m[key] = joined
+	}
+	return m
+}
+
+func formatValueBlock(title string, values url.Values) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s:\n%s", title, clicky.Map(valueMap(values)).ANSI())
+}
+
+func accessURL(req *http.Request) string {
+	if req == nil || req.URL == nil {
+		return ""
+	}
+	u := *req.URL
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+func hasDetailedTrace(config TraceConfig) bool {
+	return config.TLS ||
+		config.Headers ||
+		config.Body ||
+		config.ResponseHeaders ||
+		config.Response ||
+		config.QueryParam ||
+		config.FormParams ||
+		config.Auth
+}
+
 func newContextLogger(config TraceConfig, verbose logger.Verbose) Middleware {
 	return func(rt http.RoundTripper) http.RoundTripper {
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -149,10 +195,13 @@ func jsonLogAt(verbose logger.Verbose, req *http.Request, level int, kv []interf
 }
 
 func verbosityLevel(config TraceConfig) int {
-	if config.Body || config.Response {
+	if config.Response {
+		return 4
+	}
+	if config.Body || config.TLS {
 		return 3
 	}
-	if config.Headers || config.ResponseHeaders {
+	if config.Headers || config.ResponseHeaders || config.QueryParam || config.FormParams {
 		return 2
 	}
 	return 1
@@ -163,6 +212,10 @@ func jsonLogger(config TraceConfig, verbose logger.Verbose, rt http.RoundTripper
 	if config.Body && req.Body != nil {
 		reqBody, req.Body = readBody(req.Body)
 	}
+	var form url.Values
+	if config.FormParams && !config.Body {
+		form, _ = formParams(req)
+	}
 
 	start := time.Now()
 	resp, err := rt.RoundTrip(req)
@@ -171,30 +224,37 @@ func jsonLogger(config TraceConfig, verbose logger.Verbose, rt http.RoundTripper
 
 	kv := []interface{}{
 		"method", req.Method,
-		"url", req.URL.String(),
+		"url", accessURL(req),
 	}
 
-	if config.Timing {
+	if config.AccessLog || config.Timing {
 		kv = append(kv, "duration", elapsed.Truncate(time.Millisecond).String())
 	}
 
 	if config.Headers {
-		kv = append(kv, "headers", headerMap(req.Header))
+		kv = append(kv, "headers", headerMap(req.Header, config.RedactedHeaders...))
+	}
+	if config.QueryParam && len(req.URL.Query()) > 0 {
+		kv = append(kv, "query", valueMap(req.URL.Query()))
+	}
+	if len(form) > 0 {
+		kv = append(kv, "form", valueMap(form))
 	}
 	if config.Body && reqBody != "" {
 		kv = append(kv, "body", sanitizeBody(reqBody))
 	}
 
 	if err != nil {
+		// Transport errors surface at INFO so a failed request is visible at -v=0.
 		kv = append(kv, "error", err.Error())
-		jsonLogAt(verbose, req, level, kv, "%s %s error %s", req.Method, req.URL, elapsed.Truncate(time.Millisecond))
+		jsonLogAt(verbose, req, 0, kv, "%s %s error %s", req.Method, req.URL, elapsed.Truncate(time.Millisecond))
 		return nil, err
 	}
 
 	kv = append(kv, "status", resp.StatusCode)
 
 	if config.ResponseHeaders {
-		kv = append(kv, "responseHeaders", headerMap(resp.Header))
+		kv = append(kv, "responseHeaders", headerMap(resp.Header, config.RedactedHeaders...))
 	}
 	if config.Response && resp.Body != nil {
 		var respBody string
@@ -204,29 +264,74 @@ func jsonLogger(config TraceConfig, verbose logger.Verbose, rt http.RoundTripper
 		}
 	}
 
+	if resp.StatusCode >= 400 {
+		// Error responses surface at INFO with their body, even when the
+		// configured trace level wouldn't otherwise capture the response body.
+		if !config.Response {
+			if body := readErrorBody(resp, config.MaxBodyLength); body != "" {
+				kv = append(kv, "responseBody", sanitizeBody(body))
+			}
+		}
+		jsonLogAt(verbose, req, 0, kv, "%s %s %d %s", req.Method, req.URL, resp.StatusCode, elapsed.Truncate(time.Millisecond))
+		return resp, nil
+	}
+
+	// Error-only mode suppresses the success line (see logPrettyAccess).
+	if config.AccessLogErrorsOnly {
+		return resp, nil
+	}
 	jsonLogAt(verbose, req, level, kv, "%s %s %d %s", req.Method, req.URL, resp.StatusCode, elapsed.Truncate(time.Millisecond))
 	return resp, nil
 }
 
 func prettyLogger(config TraceConfig, verbose logger.Verbose, rt http.RoundTripper, req *http.Request) (*http.Response, error) {
+	var form url.Values
+	if config.FormParams && !config.Body {
+		form, _ = formParams(req)
+	}
+
+	detailed := hasDetailedTrace(config)
+	start := time.Now()
+	if !detailed {
+		resp, err := rt.RoundTrip(req)
+		elapsed := time.Since(start)
+		logPrettyAccess(config, verbose, req, resp, err, elapsed)
+		return resp, err
+	}
+
 	var buf bytes.Buffer
 	l := &httpretty.Logger{
-		TLS:            config.TLS,
-		RequestHeader:  config.Headers,
-		RequestBody:    config.Body,
-		ResponseHeader: config.ResponseHeaders,
-		ResponseBody:   config.Response,
-		Auth:           config.Auth,
-		Colors:         true,
-		Formatters:     []httpretty.Formatter{&jsonFormatter{}, &formURLEncodedFormatter{}},
+		TLS:             config.TLS,
+		RequestHeader:   config.Headers,
+		RequestBody:     config.Body,
+		ResponseHeader:  config.ResponseHeaders,
+		ResponseBody:    config.Response,
+		Auth:            config.Auth,
+		Colors:          true,
+		Formatters:      []httpretty.Formatter{&jsonFormatter{}, &formURLEncodedFormatter{}},
+		MaxRequestBody:  config.MaxBodyLength,
+		MaxResponseBody: config.MaxBodyLength,
+		RedactedHeaders: append(config.RedactedHeaders, logger.CommonRedactedHeaders...),
 	}
 	l.SetOutput(&buf)
 	inner := l.RoundTripper(rt)
-	start := time.Now()
 	resp, err := inner.RoundTrip(req)
 	elapsed := time.Since(start)
+	logPrettyAccess(config, verbose, req, resp, err, elapsed)
 	if buf.Len() > 0 {
 		msg := buf.String()
+		var blocks []string
+		if config.QueryParam {
+			if block := formatValueBlock("Query Params", req.URL.Query()); block != "" {
+				blocks = append(blocks, block)
+			}
+		}
+		if block := formatValueBlock("Form Params", form); block != "" {
+			blocks = append(blocks, block)
+		}
+		if len(blocks) > 0 {
+			msg = strings.TrimSpace(msg) + "\n" + strings.Join(blocks, "\n")
+		}
 		if config.Timing {
 			suffix := ""
 			if resp != nil {
@@ -250,6 +355,61 @@ func prettyLogger(config TraceConfig, verbose logger.Verbose, rt http.RoundTripp
 	return resp, err
 }
 
+func logPrettyAccess(config TraceConfig, verbose logger.Verbose, req *http.Request, resp *http.Response, err error, elapsed time.Duration) {
+	if !config.AccessLog {
+		return
+	}
+	method := console.Bluef("%s", req.Method)
+	url := console.Yellowf("%s", accessURL(req))
+	dur := elapsed.Truncate(time.Millisecond)
+
+	// Transport errors and responses >= 400 always log (with the response body),
+	// so a failing request surfaces even when the access log is installed in
+	// error-only mode at -v=0; the body captures the cause (e.g. an HTML 404/500
+	// page) without raising verbosity.
+	if err != nil {
+		logAt(verbose, req, 0, "%s %s %s %s", method, url, console.Redf("error: %s", err.Error()), dur)
+		return
+	}
+	statusCode := 0
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
+	if statusCode >= 400 {
+		logAt(verbose, req, 0, "%s %s %s %s", method, url, statusColor(statusCode)("%d", statusCode), dur)
+		if body := readErrorBody(resp, config.MaxBodyLength); body != "" {
+			logAt(verbose, req, 0, "%s", body)
+		}
+		return
+	}
+	// Error-only mode (installed one level below base) suppresses the success
+	// line; full access logging (base level and up) logs every request.
+	if config.AccessLogErrorsOnly {
+		return
+	}
+	logAt(verbose, req, 1, "%s %s %s %s", method, url, statusColor(statusCode)("%d", statusCode), dur)
+}
+
+// readErrorBody reads and restores resp.Body (so downstream consumers still see
+// it), returning the body truncated to maxLen runes. maxLen <= 0 falls back to
+// the http.log.response.body.length property (4KB default).
+func readErrorBody(resp *http.Response, maxLen int64) string {
+	if resp == nil || resp.Body == nil {
+		return ""
+	}
+	limit := maxLen
+	if limit <= 0 {
+		limit = int64(properties.Int(4*1024, "http.log.response.body.length"))
+	}
+	body, restored := readBody(resp.Body)
+	resp.Body = restored
+	body = strings.TrimSpace(body)
+	if int64(len(body)) > limit {
+		return body[:limit] + "… (truncated)"
+	}
+	return body
+}
+
 func statusColor(code int) func(string, ...interface{}) string {
 	if code >= 200 && code < 300 {
 		return console.Greenf
@@ -259,42 +419,10 @@ func statusColor(code int) func(string, ...interface{}) string {
 	return console.Yellowf
 }
 
-func newContextAccessLog(verbose logger.Verbose) Middleware {
-	return func(rt http.RoundTripper) http.RoundTripper {
-		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			start := time.Now()
-			resp, err := rt.RoundTrip(req)
-			elapsed := time.Since(start)
-
-			if logger.IsJsonLogs() {
-				kv := []interface{}{"method", req.Method, "url", req.URL.String(), "duration", elapsed.Truncate(time.Millisecond).String()}
-				if err != nil {
-					kv = append(kv, "error", err.Error())
-					jsonLogAt(verbose, req, 1, kv, "%s %s error %s", req.Method, req.URL, elapsed.Truncate(time.Millisecond))
-					return nil, err
-				}
-				kv = append(kv, "status", resp.StatusCode)
-				jsonLogAt(verbose, req, 1, kv, "%s %s %d %s", req.Method, req.URL, resp.StatusCode, elapsed.Truncate(time.Millisecond))
-				return resp, nil
-			}
-
-			if err != nil {
-				logAt(verbose, req, 1, "%s %s %s %s", console.Bluef("%s", req.Method), console.Yellowf("%s", req.URL), console.Redf("error"), elapsed.Truncate(time.Millisecond))
-				return nil, err
-			}
-			logAt(verbose, req, 1, "%s %s %s %s", console.Bluef("%s", req.Method), console.Yellowf("%s", req.URL), statusColor(resp.StatusCode)("%d", resp.StatusCode), elapsed.Truncate(time.Millisecond))
-			return resp, nil
-		})
-	}
-}
-
 func NewLogger(config TraceConfig, verbose ...logger.Verbose) Middleware {
 	var v logger.Verbose
 	if len(verbose) > 0 {
 		v = verbose[0]
-	}
-	if config.AccessLog {
-		return newContextAccessLog(v)
 	}
 	return newContextLogger(config, v)
 }

--- a/http/middlewares/trace.go
+++ b/http/middlewares/trace.go
@@ -50,6 +50,10 @@ type TraceConfig struct {
 	// QueryParam controls whether the query parameters are traced
 	QueryParam bool
 
+	// FormParams controls whether application/x-www-form-urlencoded request
+	// parameters are traced without enabling the raw request body.
+	FormParams bool
+
 	// Headers controls whether the Headers are traced
 	Headers bool
 
@@ -63,6 +67,13 @@ type TraceConfig struct {
 
 	// AccessLog enables single-line access log output: METHOD URL STATUS DURATION
 	AccessLog bool
+
+	// AccessLogErrorsOnly restricts the access log to failing requests: only
+	// transport errors and responses with status >= 400 are logged (with their
+	// body). Successful requests are silent. Set when the access log is enabled
+	// one level below the trace base, so failures surface at -v=0 without the
+	// per-request access spam full access logging produces.
+	AccessLogErrorsOnly bool
 }
 
 var traceAll = TraceConfig{
@@ -70,6 +81,7 @@ var traceAll = TraceConfig{
 	Body:            true,
 	Response:        true,
 	QueryParam:      true,
+	FormParams:      true,
 	Headers:         true,
 	ResponseHeaders: true,
 	TLS:             true,
@@ -79,6 +91,7 @@ var traceAll = TraceConfig{
 
 var traceHeaders = TraceConfig{
 	QueryParam:      true,
+	FormParams:      true,
 	Headers:         true,
 	ResponseHeaders: true,
 	Timing:          true,
@@ -123,6 +136,9 @@ func TraceConfigFromString(s string) TraceConfig {
 		if strings.Contains(s, "queryParam") {
 			config.QueryParam = true
 		}
+		if strings.Contains(s, "formParam") || strings.Contains(s, "formParams") {
+			config.FormParams = true
+		}
 		if strings.Contains(s, "tls") {
 			config.TLS = true
 		}
@@ -158,6 +174,7 @@ func (t *traceTransport) TraceAll(val bool) *traceTransport {
 	t.Config.Response = true
 	t.Config.ResponseHeaders = true
 	t.Config.QueryParam = true
+	t.Config.FormParams = true
 	t.Config.Headers = true
 	t.Config.TLS = true
 	t.Config.Timing = true
@@ -181,6 +198,11 @@ func (t *traceTransport) TraceResponseHeaders(val bool) *traceTransport {
 
 func (t *traceTransport) TraceQueryParam(val bool) *traceTransport {
 	t.Config.QueryParam = val
+	return t
+}
+
+func (t *traceTransport) TraceFormParams(val bool) *traceTransport {
+	t.Config.FormParams = val
 	return t
 }
 

--- a/http/request.go
+++ b/http/request.go
@@ -13,7 +13,16 @@ import (
 
 	"github.com/flanksource/commons/console"
 	"github.com/flanksource/commons/logger"
+	"github.com/flanksource/commons/properties"
+	"github.com/flanksource/commons/text"
 )
+
+const defaultMaxBufferSize = 4 * 1024 * 1024 // 4 MB
+
+// MaxBufferSizeProperty caps how many bytes of an io.Reader request body are
+// buffered for retry replay. Bodies larger than this stream through once and
+// cannot be retried. Set -P http.request.maxBufferSize=0 to disable the cap.
+const MaxBufferSizeProperty = "http.request.maxBufferSize"
 
 // Request represents an HTTP request that can be customized and executed.
 // It provides a fluent API for setting headers, query parameters, body, and other options.
@@ -27,6 +36,8 @@ type Request struct {
 	rawURL        string
 	url           *url.URL
 	body          io.Reader
+	bodyBytes     []byte
+	bodyBuffered  bool
 	headers       http.Header
 	queryParams   url.Values
 }
@@ -182,13 +193,36 @@ func (r *Request) RetryStrategy(fn RetryStrategy) *Request {
 func (r *Request) Body(v any) error {
 	switch t := v.(type) {
 	case io.Reader:
-		r.body = t
+		// A raw reader is single-use; buffer it once (up to maxBufferSize) so a
+		// retried attempt can replay the same bytes instead of sending an empty
+		// body. Bodies over the cap stream through un-buffered and cannot retry.
+		limit := properties.Int(defaultMaxBufferSize, MaxBufferSizeProperty)
+		if limit <= 0 {
+			b, err := io.ReadAll(t)
+			if err != nil {
+				return err
+			}
+			r.setBodyBytes(b)
+			return nil
+		}
+		// Read one byte past the cap to detect an over-limit reader without
+		// pulling the whole thing into memory.
+		prefix, err := io.ReadAll(io.LimitReader(t, int64(limit)+1))
+		if err != nil {
+			return err
+		}
+		if len(prefix) <= limit {
+			r.setBodyBytes(prefix)
+			return nil
+		}
+		logger.Debugf("request body exceeds %s buffer cap (%s); streaming un-buffered, retries disabled for this request",
+			text.HumanizeBytes(limit), MaxBufferSizeProperty)
+		r.body = io.MultiReader(bytes.NewReader(prefix), t)
+		r.bodyBuffered = false
 	case []byte:
-		buf := bytes.Buffer{}
-		buf.Write(t)
-		r.body = &buf
+		r.setBodyBytes(t)
 	case string:
-		r.body = strings.NewReader(t)
+		r.setBodyBytes([]byte(t))
 	default:
 		b, err := json.Marshal(v)
 		if err != nil {
@@ -197,6 +231,35 @@ func (r *Request) Body(v any) error {
 		return r.Body(b)
 	}
 
+	return nil
+}
+
+// setBodyBytes records the request body as a replayable byte slice and points
+// r.body at a fresh reader over it. Retries call resetBody to rewind.
+func (r *Request) setBodyBytes(b []byte) {
+	r.bodyBytes = b
+	r.bodyBuffered = true
+	r.body = bytes.NewReader(b)
+}
+
+// resetBody rewinds the request body before a retried attempt. roundTrip drains
+// r.body, so without this every retry of a body-carrying request would send an
+// empty body (a downstream JSON validation failure). A no-op when the body
+// was never buffered (e.g. a bodiless GET).
+func (r *Request) resetBody() {
+	if r.bodyBuffered {
+		r.body = bytes.NewReader(r.bodyBytes)
+	}
+}
+
+// prepareRetry rewinds a buffered body for replay, or refuses the retry when
+// the body was streamed un-buffered (over the maxBufferSize cap) — resending a
+// drained stream would silently transmit an empty body.
+func (r *Request) prepareRetry() error {
+	if !r.bodyBuffered && r.body != nil {
+		return fmt.Errorf("cannot retry request: body exceeded %s and was streamed un-buffered (raise the cap to enable retries)", MaxBufferSizeProperty)
+	}
+	r.resetBody()
 	return nil
 }
 
@@ -246,6 +309,9 @@ func (r *Request) do() (resp *Response, err error) {
 
 			retriesRemaining--
 			exponentialBackoff(r.retryConfig, retriesRemaining)
+			if err := r.prepareRetry(); err != nil {
+				return nil, err
+			}
 			continue
 		}
 
@@ -281,6 +347,9 @@ func (r *Request) doWithStrategy() (*Response, error) {
 			case <-time.After(delay):
 			}
 		}
+		if err := r.prepareRetry(); err != nil {
+			return nil, err
+		}
 	}
 }
 
@@ -311,7 +380,6 @@ func (r *Request) Debug() string {
 	if !r.client.authConfig.IsEmpty() {
 		sb.WriteString("  " + console.Grayf("%s", "Authorization: ") + r.client.authConfig.Username + ":" + logger.PrintableSecret(r.client.authConfig.Password) + "\n")
 	}
-	body, _ := io.ReadAll(r.body)
-	sb.WriteString(logger.StripSecrets(string(body)))
+	sb.WriteString(logger.StripSecrets(string(r.bodyBytes)))
 	return sb.String()
 }

--- a/http/retry_body_test.go
+++ b/http/retry_body_test.go
@@ -1,0 +1,255 @@
+package http_test
+
+import (
+	"context"
+	"io"
+	netHTTP "net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/flanksource/commons/http"
+	"github.com/flanksource/commons/properties"
+)
+
+// stallingServer records every request body it receives and stalls the first
+// attempt past the client timeout, forcing the transport-error retry path.
+func stallingServer(t *testing.T, bodies *[]string, mu *sync.Mutex, attempts *int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(netHTTP.HandlerFunc(func(w netHTTP.ResponseWriter, r *netHTTP.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		*attempts++
+		n := *attempts
+		*bodies = append(*bodies, string(b))
+		mu.Unlock()
+		if n == 1 {
+			time.Sleep(200 * time.Millisecond)
+		}
+		w.WriteHeader(netHTTP.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// A retried POST must replay the request body on every attempt. roundTrip
+// drains the body reader, so before the fix a retry sent an empty body — the
+// downstream JSON validation failure. The retry path fires on a transport
+// error, so the server stalls the first attempt past the client timeout to
+// force it, then records the body every attempt received.
+func TestRetryReplaysRequestBody(t *testing.T) {
+	const payload = `{"hello":"world"}`
+
+	var (
+		mu       sync.Mutex
+		bodies   []string
+		attempts int
+	)
+	srv := httptest.NewServer(netHTTP.HandlerFunc(func(w netHTTP.ResponseWriter, r *netHTTP.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		attempts++
+		n := attempts
+		bodies = append(bodies, string(b))
+		mu.Unlock()
+		if n == 1 {
+			// Stall past the client timeout to trigger the transport-error
+			// retry path (the production processDynamicFieldChange timeout).
+			time.Sleep(200 * time.Millisecond)
+		}
+		w.WriteHeader(netHTTP.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp, err := http.NewClient().
+		BaseURL(srv.URL).
+		Timeout(50*time.Millisecond).
+		Retry(3, time.Millisecond, 1.0).
+		R(context.Background()).
+		Post("/", payload)
+	if err != nil {
+		t.Fatalf("request errored: %v", err)
+	}
+	if !resp.IsOK() {
+		t.Fatalf("expected eventual 200, got %d", resp.StatusCode)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts < 2 {
+		t.Fatalf("expected a retry (>=2 attempts), got %d", attempts)
+	}
+	for i, got := range bodies {
+		if got != payload {
+			t.Errorf("attempt %d received body %q, want %q (body must replay on retry)", i+1, got, payload)
+		}
+	}
+}
+
+// The same guarantee holds when the body is supplied as a raw io.Reader: it is
+// buffered once so the retry can replay it rather than re-reading an exhausted
+// stream.
+func TestRetryReplaysReaderBody(t *testing.T) {
+	const payload = "raw-reader-body"
+
+	var (
+		mu       sync.Mutex
+		bodies   []string
+		attempts int
+	)
+	srv := httptest.NewServer(netHTTP.HandlerFunc(func(w netHTTP.ResponseWriter, r *netHTTP.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		attempts++
+		n := attempts
+		bodies = append(bodies, string(b))
+		mu.Unlock()
+		if n == 1 {
+			time.Sleep(200 * time.Millisecond)
+		}
+		w.WriteHeader(netHTTP.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp, err := http.NewClient().
+		BaseURL(srv.URL).
+		Timeout(50*time.Millisecond).
+		Retry(3, time.Millisecond, 1.0).
+		R(context.Background()).
+		Post("/", io.Reader(strings.NewReader(payload)))
+	if err != nil {
+		t.Fatalf("request errored: %v", err)
+	}
+	if !resp.IsOK() {
+		t.Fatalf("expected eventual 200, got %d", resp.StatusCode)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for i, got := range bodies {
+		if got != payload {
+			t.Errorf("attempt %d received body %q, want %q (reader body must buffer and replay)", i+1, got, payload)
+		}
+	}
+}
+
+// A reader body at/under the configured cap is still buffered and replayed on
+// retry, exactly as the default case — the cap only changes behavior above it.
+func TestRequestBodyUnderCapStillBuffers(t *testing.T) {
+	properties.Set(http.MaxBufferSizeProperty, 1024)
+	t.Cleanup(func() { properties.Set(http.MaxBufferSizeProperty, "") })
+
+	payload := strings.Repeat("a", 512) // under the 1024 cap
+
+	var (
+		mu       sync.Mutex
+		bodies   []string
+		attempts int
+	)
+	srv := stallingServer(t, &bodies, &mu, &attempts)
+
+	resp, err := http.NewClient().
+		BaseURL(srv.URL).
+		Timeout(50*time.Millisecond).
+		Retry(3, time.Millisecond, 1.0).
+		R(context.Background()).
+		Post("/", io.Reader(strings.NewReader(payload)))
+	if err != nil {
+		t.Fatalf("request errored: %v", err)
+	}
+	if !resp.IsOK() {
+		t.Fatalf("expected eventual 200, got %d", resp.StatusCode)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts < 2 {
+		t.Fatalf("expected a retry (>=2 attempts), got %d", attempts)
+	}
+	for i, got := range bodies {
+		if got != payload {
+			t.Errorf("attempt %d received body %q (len %d), want full payload (len %d): body under cap must replay", i+1, got, len(got), len(payload))
+		}
+	}
+}
+
+// A reader body over the cap streams through un-buffered: the first attempt
+// receives the full payload, but a retry is refused with an explicit error
+// rather than silently resending an empty body.
+func TestRequestBodyOverCapStreamsOnceAndRefusesRetry(t *testing.T) {
+	properties.Set(http.MaxBufferSizeProperty, 16)
+	t.Cleanup(func() { properties.Set(http.MaxBufferSizeProperty, "") })
+
+	payload := strings.Repeat("b", 1024) // well over the 16-byte cap
+
+	var (
+		mu       sync.Mutex
+		bodies   []string
+		attempts int
+	)
+	srv := stallingServer(t, &bodies, &mu, &attempts)
+
+	_, err := http.NewClient().
+		BaseURL(srv.URL).
+		Timeout(50*time.Millisecond).
+		Retry(3, time.Millisecond, 1.0).
+		R(context.Background()).
+		Post("/", io.Reader(strings.NewReader(payload)))
+	if err == nil {
+		t.Fatal("expected retry of an over-cap streamed body to error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot retry request: body exceeded") {
+		t.Fatalf("expected over-cap retry-refusal error, got: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(bodies) == 0 {
+		t.Fatal("server received no request")
+	}
+	if bodies[0] != payload {
+		t.Errorf("first attempt received body len %d, want full payload len %d: over-cap body must stream intact once", len(bodies[0]), len(payload))
+	}
+}
+
+// Setting the cap to 0 disables it: a body larger than the default 4 MB cap is
+// fully buffered and replayed on retry.
+func TestRequestBodyCapDisabled(t *testing.T) {
+	properties.Set(http.MaxBufferSizeProperty, 0)
+	t.Cleanup(func() { properties.Set(http.MaxBufferSizeProperty, "") })
+
+	payload := strings.Repeat("c", 5*1024*1024) // > 4 MB default cap
+
+	var (
+		mu       sync.Mutex
+		bodies   []string
+		attempts int
+	)
+	srv := stallingServer(t, &bodies, &mu, &attempts)
+
+	resp, err := http.NewClient().
+		BaseURL(srv.URL).
+		Timeout(50*time.Millisecond).
+		Retry(3, time.Millisecond, 1.0).
+		R(context.Background()).
+		Post("/", io.Reader(strings.NewReader(payload)))
+	if err != nil {
+		t.Fatalf("request errored: %v", err)
+	}
+	if !resp.IsOK() {
+		t.Fatalf("expected eventual 200, got %d", resp.StatusCode)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts < 2 {
+		t.Fatalf("expected a retry (>=2 attempts), got %d", attempts)
+	}
+	for i, got := range bodies {
+		if got != payload {
+			t.Errorf("attempt %d received body len %d, want full payload len %d: disabled cap must buffer and replay", i+1, len(got), len(payload))
+		}
+	}
+}

--- a/http/with_context_test.go
+++ b/http/with_context_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"io"
 	netHTTP "net/http"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/flanksource/commons/har"
 	"github.com/flanksource/commons/logger"
+	"github.com/flanksource/commons/properties"
 )
 
 // fakeContext implements CommonsHTTPContext for the WithContext tests.
@@ -42,13 +44,19 @@ func TestWithLoggerLadder(t *testing.T) {
 		name              string
 		level             logger.LogLevel
 		expectTrace       bool
+		wantAccessLog     bool
 		wantHeaders       bool
+		wantFormParams    bool
+		wantTLS           bool
 		wantBody          bool
+		wantResponse      bool
 		wantMaxBodyLength int64
 	}{
-		{name: "info: no trace middleware", level: logger.Info, expectTrace: false},
-		{name: "trace1: headers only", level: logger.Trace1, expectTrace: true, wantHeaders: true, wantBody: false},
-		{name: "trace2: headers + body", level: logger.Trace2, expectTrace: true, wantHeaders: true, wantBody: true, wantMaxBodyLength: 4096},
+		{name: "info: error-only access log installed", level: logger.Info, expectTrace: true, wantAccessLog: true},
+		{name: "debug: access log only", level: logger.Debug, expectTrace: true, wantAccessLog: true},
+		{name: "trace: params + headers", level: logger.Trace, expectTrace: true, wantAccessLog: true, wantHeaders: true, wantFormParams: true},
+		{name: "trace1: request body + tls", level: logger.Trace1, expectTrace: true, wantAccessLog: true, wantHeaders: true, wantFormParams: true, wantTLS: true, wantBody: true, wantMaxBodyLength: 4096},
+		{name: "trace2: response body", level: logger.Trace2, expectTrace: true, wantAccessLog: true, wantHeaders: true, wantFormParams: true, wantTLS: true, wantBody: true, wantResponse: true, wantMaxBodyLength: 4096},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -68,8 +76,20 @@ func TestWithLoggerLadder(t *testing.T) {
 				if c.traceConfig.Headers != tc.wantHeaders {
 					t.Errorf("Headers: got %v want %v", c.traceConfig.Headers, tc.wantHeaders)
 				}
+				if c.traceConfig.AccessLog != tc.wantAccessLog {
+					t.Errorf("AccessLog: got %v want %v", c.traceConfig.AccessLog, tc.wantAccessLog)
+				}
+				if c.traceConfig.FormParams != tc.wantFormParams {
+					t.Errorf("FormParams: got %v want %v", c.traceConfig.FormParams, tc.wantFormParams)
+				}
+				if c.traceConfig.TLS != tc.wantTLS {
+					t.Errorf("TLS: got %v want %v", c.traceConfig.TLS, tc.wantTLS)
+				}
 				if c.traceConfig.Body != tc.wantBody {
 					t.Errorf("Body: got %v want %v", c.traceConfig.Body, tc.wantBody)
+				}
+				if c.traceConfig.Response != tc.wantResponse {
+					t.Errorf("Response: got %v want %v", c.traceConfig.Response, tc.wantResponse)
 				}
 				if c.traceConfig.MaxBodyLength != tc.wantMaxBodyLength {
 					t.Errorf("MaxBodyLength: got %d want %d", c.traceConfig.MaxBodyLength, tc.wantMaxBodyLength)
@@ -89,12 +109,58 @@ func TestWithLoggerLadder(t *testing.T) {
 	}
 }
 
-// TestWithContextMergesTraceConfig: WithLogger at Trace1 installs the
-// headers-only config; WithContext then returns a body-only TraceConfig.
-// After merge the single installed middleware should have both Headers
-// and Body true.
+func TestTraceConfigForLogLevelBaseLevel(t *testing.T) {
+	properties.Set("http.log.base-level", "")
+	t.Setenv("HTTP_LOG_BASE_LEVEL", "")
+
+	cfg, ok := TraceConfigForLogLevel(logger.Info, WithTraceBaseLevel(logger.Info))
+	if !ok {
+		t.Fatalf("Info should enable trace when base is Info")
+	}
+	if !cfg.AccessLog || cfg.Headers || cfg.Body || cfg.Response {
+		t.Fatalf("Info/base Info config = %+v, want access only", cfg)
+	}
+
+	cfg, ok = TraceConfigForLogLevel(logger.Trace, WithTraceBaseLevel(logger.Info))
+	if !ok {
+		t.Fatalf("Trace should enable trace when base is Info")
+	}
+	if !cfg.Body || !cfg.TLS || cfg.Response {
+		t.Fatalf("Trace/base Info config = %+v, want request body + tls but no response", cfg)
+	}
+
+	// One level below base installs the access log in error-only mode.
+	if cfg, ok := TraceConfigForLogLevel(logger.Debug, WithTraceBaseLevel(logger.Trace)); !ok {
+		t.Fatalf("Debug (base-1 of a Trace base) should install the error-only access log")
+	} else if !cfg.AccessLog || cfg.Headers || cfg.Body || cfg.Response {
+		t.Fatalf("Debug/base Trace config = %+v, want access only", cfg)
+	}
+
+	// Two levels below base installs nothing.
+	if _, ok := TraceConfigForLogLevel(logger.Info, WithTraceBaseLevel(logger.Trace)); ok {
+		t.Fatalf("Info (base-2 of a Trace base) should install no trace middleware")
+	}
+}
+
+func TestTraceConfigForLogLevelReadsConfiguredBase(t *testing.T) {
+	properties.Set("http.log.base-level", "info")
+	t.Cleanup(func() { properties.Set("http.log.base-level", "") })
+	t.Setenv("HTTP_LOG_BASE_LEVEL", "")
+
+	cfg, ok := TraceConfigForLogLevel(logger.Info)
+	if !ok {
+		t.Fatalf("Info should enable trace when http.log.base-level=info")
+	}
+	if !cfg.AccessLog || cfg.Headers || cfg.Body {
+		t.Fatalf("Info/property base config = %+v, want access only", cfg)
+	}
+}
+
+// TestWithContextMergesTraceConfig: WithLogger at Trace installs the
+// params+headers config; WithContext then returns a body-only TraceConfig.
+// After merge the single installed middleware should have Headers and Body.
 func TestWithContextMergesTraceConfig(t *testing.T) {
-	l := newTestLogger(t, logger.Trace1)
+	l := newTestLogger(t, logger.Trace)
 	ctx := &fakeContext{
 		log:      l,
 		traceCfg: TraceConfig{Body: true, Response: true, MaxBodyLength: 2048},
@@ -123,6 +189,195 @@ func TestWithContextMergesTraceConfig(t *testing.T) {
 	if !hasHeaderCaseInsensitive(cfg.RedactedHeaders, "Authorization") {
 		t.Errorf("Authorization must be redacted after WithContext: %v", cfg.RedactedHeaders)
 	}
+}
+
+func TestWithLoggerHTTPOutputLadder(t *testing.T) {
+	srv := httptest.NewServer(netHTTP.HandlerFunc(func(w netHTTP.ResponseWriter, r *netHTTP.Request) {
+		_, _ = io.ReadAll(r.Body)
+		w.Header().Set("X-Response-Key", "response-secret")
+		w.WriteHeader(netHTTP.StatusCreated)
+		_, _ = w.Write([]byte("response-body"))
+	}))
+	defer srv.Close()
+
+	cases := []struct {
+		name    string
+		level   logger.LogLevel
+		want    []string
+		wantNot []string
+	}{
+		{
+			name:    "debug access line",
+			level:   logger.Debug,
+			want:    []string{"POST", "201"},
+			wantNot: []string{"q=visible", "Query Params", "Form Params", "X-Api-Key", "foo", "response-body"},
+		},
+		{
+			name:    "trace params and headers",
+			level:   logger.Trace,
+			want:    []string{"POST", "201", "Query Params", "q", "visible", "Form Params", "foo", "bar", "X-Api-Key", "X-Response-Key"},
+			wantNot: []string{"rawsecret", "supersecret", "response-secret", "response-body"},
+		},
+		{
+			name:    "trace1 request body only",
+			level:   logger.Trace1,
+			want:    []string{"POST", "201", "foo", "bar"},
+			wantNot: []string{"supersecret", "response-body"},
+		},
+		{
+			name:    "trace2 response body",
+			level:   logger.Trace2,
+			want:    []string{"POST", "201", "foo", "bar", "response-body"},
+			wantNot: []string{"supersecret", "response-secret"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := captureLogOutput(t)
+			l := newTestLogger(t, tc.level)
+			resp, err := NewClient().
+				WithLogger(l).
+				Header("Content-Type", "application/x-www-form-urlencoded").
+				Header("X-Api-Key", "rawsecret").
+				R(context.Background()).
+				QueryParam("q", "visible").
+				Post(srv.URL+"/submit", "foo=bar&password=supersecret")
+			if err != nil {
+				t.Fatalf("Post: %v", err)
+			}
+			defer resp.Body.Close()
+
+			got := out.String()
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("output missing %q:\n%s", want, got)
+				}
+			}
+			for _, wantNot := range tc.wantNot {
+				if strings.Contains(got, wantNot) {
+					t.Errorf("output unexpectedly contains %q:\n%s", wantNot, got)
+				}
+			}
+		})
+	}
+}
+
+func TestWithLoggerRequestBodyStartsAtTrace1(t *testing.T) {
+	srv := httptest.NewServer(netHTTP.HandlerFunc(func(w netHTTP.ResponseWriter, r *netHTTP.Request) {
+		_, _ = io.ReadAll(r.Body)
+		w.WriteHeader(netHTTP.StatusOK)
+	}))
+	defer srv.Close()
+
+	for _, tc := range []struct {
+		name     string
+		level    logger.LogLevel
+		wantBody bool
+	}{
+		{name: "trace omits raw request body", level: logger.Trace, wantBody: false},
+		{name: "trace1 prints request body", level: logger.Trace1, wantBody: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := captureLogOutput(t)
+			l := newTestLogger(t, tc.level)
+			resp, err := NewClient().
+				WithLogger(l).
+				Header("Content-Type", "application/json").
+				R(context.Background()).
+				Post(srv.URL+"/json", `{"message":"request-body-marker"}`)
+			if err != nil {
+				t.Fatalf("Post: %v", err)
+			}
+			defer resp.Body.Close()
+
+			contains := strings.Contains(out.String(), "request-body-marker")
+			if contains != tc.wantBody {
+				t.Fatalf("request body presence = %v, want %v:\n%s", contains, tc.wantBody, out.String())
+			}
+		})
+	}
+}
+
+// TestErrorResponseLoggedAtInfo asserts the error-only access log behaviour:
+// at INFO (-v=0) a >= 400 response logs its access line and body, while a 2xx
+// response stays silent; at DEBUG (-v=1) the 2xx access line appears.
+func TestErrorResponseLoggedAtInfo(t *testing.T) {
+	const html = "<html><body><h1>HTTP Status 404 – Not Found</h1></body></html>"
+	srv := httptest.NewServer(netHTTP.HandlerFunc(func(w netHTTP.ResponseWriter, r *netHTTP.Request) {
+		_, _ = io.ReadAll(r.Body)
+		if strings.HasSuffix(r.URL.Path, "/missing") {
+			w.WriteHeader(netHTTP.StatusNotFound)
+			_, _ = w.Write([]byte(html))
+			return
+		}
+		w.WriteHeader(netHTTP.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	t.Run("404 surfaces access line and body at INFO", func(t *testing.T) {
+		out := captureLogOutput(t)
+		resp, err := NewClient().WithLogger(newTestLogger(t, logger.Info)).
+			R(context.Background()).Get(srv.URL + "/missing")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		defer resp.Body.Close()
+
+		got := out.String()
+		for _, want := range []string{"GET", "404", "HTTP Status 404"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("INFO output missing %q:\n%s", want, got)
+			}
+		}
+
+		// The body must still be readable downstream (readErrorBody restores it).
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != html {
+			t.Errorf("response body not restored after logging: got %q", string(body))
+		}
+	})
+
+	t.Run("2xx is silent at INFO", func(t *testing.T) {
+		out := captureLogOutput(t)
+		resp, err := NewClient().WithLogger(newTestLogger(t, logger.Info)).
+			R(context.Background()).Get(srv.URL + "/ok")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if got := strings.TrimSpace(out.String()); got != "" {
+			t.Errorf("a successful request must not log at INFO; got:\n%s", got)
+		}
+	})
+
+	t.Run("2xx access line appears at DEBUG", func(t *testing.T) {
+		out := captureLogOutput(t)
+		resp, err := NewClient().WithLogger(newTestLogger(t, logger.Debug)).
+			R(context.Background()).Get(srv.URL + "/ok")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		defer resp.Body.Close()
+
+		got := out.String()
+		for _, want := range []string{"GET", "200"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("DEBUG output missing %q:\n%s", want, got)
+			}
+		}
+	})
+}
+
+func captureLogOutput(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var out bytes.Buffer
+	prev := logger.GetOutput()
+	logger.SetOutput(&out)
+	t.Cleanup(func() { logger.SetOutput(prev) })
+	return &out
 }
 
 // TestTraceToStdoutDedupe: calling TraceToStdout twice on the same

--- a/logger/httpretty/httpretty.go
+++ b/logger/httpretty/httpretty.go
@@ -117,6 +117,10 @@ type Logger struct {
 	// SkipSanitize bypasses sanitizing headers containing credentials (such as Authorization).
 	SkipSanitize bool
 
+	// RedactedHeaders contains additional header names or wildcard patterns
+	// whose values should be printed redacted.
+	RedactedHeaders []string
+
 	// Auth set to print OAuth / AWSSigned requests with redacted Authorization header and additional information about the signature.
 	Auth bool
 

--- a/logger/httpretty/printer.go
+++ b/logger/httpretty/printer.go
@@ -576,6 +576,7 @@ func (p *printer) format(s ...interface{}) string {
 func (p *printer) printHeaders(prefix rune, h http.Header) {
 	if !p.logger.SkipSanitize {
 		h = header.Sanitize(header.DefaultSanitizers, h)
+		h = sanitizeRedactedHeaders(h, p.logger.RedactedHeaders)
 	}
 
 	longest, sorted := sortHeaderKeys(h, p.logger.cloneSkipHeader())
@@ -592,6 +593,63 @@ func (p *printer) printHeaders(prefix rune, h http.Header) {
 				p.format(color.FgYellow, v))
 		}
 	}
+}
+
+func sanitizeRedactedHeaders(h http.Header, patterns []string) http.Header {
+	if len(patterns) == 0 {
+		return h
+	}
+
+	out := h.Clone()
+	for key, values := range out {
+		if !matchHeaderPattern(key, patterns...) {
+			continue
+		}
+		redacted := make([]string, 0, len(values))
+		for _, value := range values {
+			redacted = append(redacted, redactHeaderValue(value))
+		}
+		out[key] = redacted
+	}
+	return out
+}
+
+func matchHeaderPattern(item string, patterns ...string) bool {
+	itemLower := strings.ToLower(http.CanonicalHeaderKey(item))
+	for _, pattern := range patterns {
+		patternLower := strings.ToLower(http.CanonicalHeaderKey(strings.TrimSpace(pattern)))
+		switch {
+		case patternLower == "" || patternLower == "!":
+			continue
+		case patternLower == "*":
+			return true
+		case strings.HasPrefix(patternLower, "*") && strings.HasSuffix(patternLower, "*"):
+			if strings.Contains(itemLower, strings.Trim(patternLower, "*")) {
+				return true
+			}
+		case strings.HasPrefix(patternLower, "*"):
+			if strings.HasSuffix(itemLower, strings.TrimPrefix(patternLower, "*")) {
+				return true
+			}
+		case strings.HasSuffix(patternLower, "*"):
+			if strings.HasPrefix(itemLower, strings.TrimSuffix(patternLower, "*")) {
+				return true
+			}
+		case itemLower == patternLower:
+			return true
+		}
+	}
+	return false
+}
+
+func redactHeaderValue(value string) string {
+	if value == "" {
+		return ""
+	}
+	if scheme, credential, ok := strings.Cut(value, " "); ok && credential != "" {
+		return scheme + " " + strings.Repeat("█", 8)
+	}
+	return strings.Repeat("█", 8)
 }
 
 func sortHeaderKeys(h http.Header, skipped map[string]struct{}) (int, []string) {


### PR DESCRIPTION
## What
- Introduce `RetryStrategy` callback-based retry mechanism with `RetryOnStatus` helper
- Add `WithContext` and `WithLogger` for context-driven HTTP client configuration
- Implement request body buffering (default 4 MB cap) to enable retry replay of `io.Reader` bodies
- Add HAR collection via `metadataHARMiddleware` and `WriteHARFile` serialization
- Configurable trace levels via `TraceConfigForLogLevel` (replaces `traceConfigForLevel`)
- Support form parameter tracing and configurable body size limits
- Enhanced access logging with error-only mode and improved header redaction

## Why
- Enable custom retry logic and Retry-After header parsing
- Support per-feature HTTP tracing and HAR collection from context
- Allow single-use readers to be retried without losing body content
- Make verbosity flags (-v, -vv, -vvv) automatically enable appropriate tracing
- Improve observability with configurable access logs and body limits

## Breaking Changes
- `Client.traceMW` and related internals now exposed; middleware stacking behavior may differ
- `traceConfigForLevel` renamed to `TraceConfigForLogLevel` with different behavior
- `NewLogger` no longer accepts `AccessLog` config; use `TraceConfig.AccessLog` instead
- Access log behavior changed: error-only mode surfaces failures at -v=0

## Notes
- Bodies exceeding buffer cap stream un-buffered and refuse retries with explicit error
- HAR capture is low-cost (headers/timing only, no bodies by default)
- Trace deduplication merges configs into single middleware instead of stacking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Request bodies can now be buffered and replayed on retries, with configurable size limit via `http.request.maxBufferSize`
  * Form parameters can be traced in HTTP requests
  * HAR capture size is now customizable via `http.har.maxBodySize` property
  * HTTP trace logging levels are now configurable based on logger level
  * Added header redaction support for sensitive values

* **Tests**
  * Added comprehensive tests for request body retry behavior
  * Added tests for HAR and trace configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->