### PR TITLE
ci(release): authenticate semantic-release via Flanksource GitHub App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,23 @@ jobs:
         with:
           egress-policy: audit
 
+      # Mint a GitHub App installation token for the Flanksource App so
+      # semantic-release can push the release tag and create the GitHub Release.
+      # The default GITHUB_TOKEN is blocked from these writes by org policy.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.FLANKSOURCE_APP_ID }}
+          private-key: ${{ secrets.FLANKSOURCE_APP_SECRET }}
+
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - uses: codfish/semantic-release-action@b621d34fabe0940f031e89b6ebfea28322892a10 # v3.5.0
         id: semantic
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   bump-clients:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Current, mergeable version of the release-auth fix — **supersedes the stale #323**
(which predates the `fix(security)` commit now on master).

commons' *Create Release* workflow runs `semantic-release` on push to `master`, but
the default `GITHUB_TOKEN` is blocked by org policy from pushing tags / creating
releases. So **no semver tag has been cut since `v1.53.1`**, even though a `feat:`
and two `fix:`es have since landed on master (`51910b8`, `516bc6d`, `a599996`).

This mints a Flanksource GitHub App installation token and hands it to `checkout`
+ `semantic-release`, matching the pattern already used in sibling repos'
(clicky-ui, mission-control-oipa) release workflows.

**On merge**, the workflow re-runs on master with working auth and cuts the pending
release (≈ `v1.54.0`, driven by the `feat:`), which downstream consumers pinning a
pseudo-version (e.g. `mission-control-oipa` at `…-516bc6d`) can then move to a tag.

Cherry-pick of `33419da` (#323) onto current `master`.
